### PR TITLE
style tweaks

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -154,7 +154,7 @@ strong, b {
 }
 
 .post ul, .project ul, .post ol  {
-	list-style-position: inside;
+	//list-style-position: inside;
 }
 
 main {
@@ -195,4 +195,8 @@ section {
 	display:flex;
 	flex-direction:column;
 	
+}
+
+figcaption {
+    font-size: smaller;
 }


### PR DESCRIPTION
remove list-style-position: inside for post lists to keep bullets aligned with first line of list item
add figcaption { font-size: smaller; } to create contrast between figure captions and ordinary post text