### PR TITLE
Fix typo and remove extraneous footer content in post layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,16 +5,8 @@ layout: default
 <section class="post">
   <h2>{{ page.title }}</h2>
   {{ content }}
-      
-
   <span class="meta"><time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time> &middot; {% for tag in page.tags %}
     <a href="/tag/{{tag}}">{{tag}}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}</span>
-
-
-  
-  <!--<span class="meta"><time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time> &middot; {% for tag in page.tags %}
-      <a class="post" href="/tag/{{tag}}">{{tag}}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}</span>
-  -->
 </section>
 
 

--- a/search.json
+++ b/search.json
@@ -10,7 +10,7 @@ layout: null
       "category" : "{{post.categories | join: ', '}}",
       "tags"     : "{{ post.tags | join: ', ' }}",
       "date"     : "{{ post.date }}",
-      "discription" : "{{post.description | strip_html | strip_newlines | escape }}"
+      "description" : "{{post.description | strip_html | strip_newlines | escape }}"
 
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}


### PR DESCRIPTION
1. Fixes a typo ("discription" -> "description")
2. Removes extraneous duplicate commented out date/tags markup from the post layout file