### PR TITLE
Update navigation.yml

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,8 +2,8 @@ links:
 - title: Writing
   url: /
 - title: About
-  url: /about
+  url: /about/
 - title: Search
-  url: /search
+  url: /search/
 - title: Rss
   url: /atom.xml


### PR DESCRIPTION
Since `page.url` will have a trailing slash, we must manually add the trailing slash here to get the nav highlighting to work properly.